### PR TITLE
fix: input validation

### DIFF
--- a/singaporetaxi18n.js
+++ b/singaporetaxi18n.js
@@ -135,7 +135,8 @@ let app = new Vue({
     methods: {
 
         calculateAll: function() {
-            this.salary = parseInt(this.uiSalary);
+            this.salary = Math.max(1, parseInt(Math.min(Number.MAX_SAFE_INTEGER, this.uiSalary)));
+            this.uiSalary = this.salary
             this.taxableIncome = this.salary;
             this.calculateCpfWithholdAmount();
             this.calculateReliefTaxAmount();
@@ -173,8 +174,10 @@ let app = new Vue({
         calculateReliefTaxAmount: function() {
             let cpfTopUpMax = this.isPermanentResident ? 8000 : 0;
             let srsTopUpMax = this.isPermanentResident ? 15300 : 35700;
-            let cpfTopUpAmount = this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax : this.cpfTopUp;
-            let srsTopUpAmount = this.srsTopUp > srsTopUpMax ? srsTopUpMax : this.srsTopUp;
+            let cpfTopUpAmount =  Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp);
+            let srsTopUpAmount =  Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp);
+            this.cpfTopUp = this.isPermanentResident ? cpfTopUpAmount : this.cpfTopUp;
+            this.srsTopUp = srsTopUpAmount;
             let totalTopUpAmount = cpfTopUpAmount + srsTopUpAmount;
             let taxableIncome = this.taxableIncome - this.cpfWithholdAmount;
             this.reliefTaxAmount = 0;

--- a/singaporetaxi18n.js
+++ b/singaporetaxi18n.js
@@ -83,6 +83,9 @@ let app = new Vue({
         salary: 0,
         cpfTopUp: 8000,
         srsTopUp: 15300,
+        previousUiSalary: 75400,
+        previousCpfTopUp: 8000,
+        previousSrsTopUp: 15300,
         isPermanentResident: false,
         isNonResident: false,
         isCPFTopUp: false,
@@ -135,8 +138,11 @@ let app = new Vue({
     methods: {
 
         calculateAll: function() {
-            this.salary = Math.max(1, parseInt(Math.min(Number.MAX_SAFE_INTEGER, this.uiSalary)));
-            this.uiSalary = this.salary
+            if(this.uiSalary !== Math.max(1, parseInt(Math.min(Number.MAX_SAFE_INTEGER, this.uiSalary)))) {
+                this.uiSalary = Math.max(1, this.previousUiSalary);
+            }
+            this.previousUiSalary = this.uiSalary;
+            this.salary = this.uiSalary;
             this.taxableIncome = this.salary;
             this.calculateCpfWithholdAmount();
             this.calculateReliefTaxAmount();
@@ -172,14 +178,22 @@ let app = new Vue({
         },
 
         calculateReliefTaxAmount: function() {
-            let cpfTopUpMax = this.isPermanentResident ? 8000 : 0;
-            let srsTopUpMax = this.isPermanentResident ? 15300 : 35700;
-            let cpfTopUpAmount =  Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp);
-            let srsTopUpAmount =  Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp);
-            this.cpfTopUp = this.isPermanentResident ? cpfTopUpAmount : this.cpfTopUp;
-            this.srsTopUp = srsTopUpAmount;
-            let totalTopUpAmount = cpfTopUpAmount + srsTopUpAmount;
-            let taxableIncome = this.taxableIncome - this.cpfWithholdAmount;
+            const cpfTopUpMax = this.isPermanentResident ? 8000 : 0;
+            if(this.cpfTopUp !== Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp)) {
+                this.cpfTopUp = Math.max(0, this.previousCpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.previousCpfTopUp);
+            }
+            this.previousCpfTopUp = this.cpfTopUp;
+
+            const srsTopUpMax = this.isPermanentResident ? 15300 : 35700;
+            if(this.srsTopUp !== Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp)) {
+                this.srsTopUp = Math.max(0, this.previousSrsTopUp > srsTopUpMax ? srsTopUpMax :this.previousSrsTopUp);
+            }
+            this.previousSrsTopUp = this.srsTopUp;
+
+            const cpfTopUpAmount =  this.cpfTopUp;
+            const srsTopUpAmount =  this.srsTopUp;
+            const totalTopUpAmount = cpfTopUpAmount + srsTopUpAmount;
+            const taxableIncome = this.taxableIncome - this.cpfWithholdAmount;
             this.reliefTaxAmount = 0;
 
             if ((this.isCPFTopUp && this.isSRSTopUp) && (taxableIncome >= totalTopUpAmount)) {

--- a/singaporetaxi18n.js
+++ b/singaporetaxi18n.js
@@ -179,14 +179,14 @@ let app = new Vue({
 
         calculateReliefTaxAmount: function() {
             const cpfTopUpMax = this.isPermanentResident ? 8000 : 0;
-            if (this.isPermanentResident && this.cpfTopUp !== Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp)) {
-                this.cpfTopUp = Math.max(0, this.previousCpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.previousCpfTopUp);
+            if (this.isPermanentResident && this.cpfTopUp !== Math.max(0, Math.min(this.cpfTopUp, cpfTopUpMax))) {
+                this.cpfTopUp = Math.max(0, Math.min(this.previousCpfTopUp, cpfTopUpMax));
             }
             this.previousCpfTopUp = this.cpfTopUp;
 
             const srsTopUpMax = this.isPermanentResident ? 15300 : 35700;
-            if (!this.isNonResident && this.srsTopUp !== Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp)) {
-                this.srsTopUp = Math.max(0, this.previousSrsTopUp > srsTopUpMax ? srsTopUpMax :this.previousSrsTopUp);
+            if (!this.isNonResident && this.srsTopUp !== Math.max(0, Math.min(this.srsTopUp, srsTopUpMax))) {
+                this.srsTopUp = Math.max(0, Math.min(this.previousSrsTopUp, srsTopUpMax));
             }
             this.previousSrsTopUp = this.srsTopUp;
 

--- a/singaporetaxi18n.js
+++ b/singaporetaxi18n.js
@@ -179,13 +179,13 @@ let app = new Vue({
 
         calculateReliefTaxAmount: function() {
             const cpfTopUpMax = this.isPermanentResident ? 8000 : 0;
-            if (this.cpfTopUp !== Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp)) {
+            if (this.isPermanentResident && this.cpfTopUp !== Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp)) {
                 this.cpfTopUp = Math.max(0, this.previousCpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.previousCpfTopUp);
             }
             this.previousCpfTopUp = this.cpfTopUp;
 
             const srsTopUpMax = this.isPermanentResident ? 15300 : 35700;
-            if (this.srsTopUp !== Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp)) {
+            if (!this.isNonResident && this.srsTopUp !== Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp)) {
                 this.srsTopUp = Math.max(0, this.previousSrsTopUp > srsTopUpMax ? srsTopUpMax :this.previousSrsTopUp);
             }
             this.previousSrsTopUp = this.srsTopUp;

--- a/singaporetaxi18n.js
+++ b/singaporetaxi18n.js
@@ -196,7 +196,10 @@ let app = new Vue({
             const taxableIncome = this.taxableIncome - this.cpfWithholdAmount;
             this.reliefTaxAmount = 0;
 
-            if ((this.isCPFTopUp && this.isSRSTopUp) && (taxableIncome >= totalTopUpAmount)) {
+            if (this.isNonResident) {
+                //
+            }
+            else if ((this.isCPFTopUp && this.isSRSTopUp) && (taxableIncome >= totalTopUpAmount)) {
                 this.reliefTaxAmount = totalTopUpAmount;
             }
             else if (this.isSRSTopUp && taxableIncome >= srsTopUpAmount) {

--- a/singaporetaxi18n.js
+++ b/singaporetaxi18n.js
@@ -138,7 +138,7 @@ let app = new Vue({
     methods: {
 
         calculateAll: function() {
-            if(this.uiSalary !== Math.max(1, parseInt(Math.min(Number.MAX_SAFE_INTEGER, this.uiSalary)))) {
+            if (this.uiSalary !== Math.max(1, parseInt(Math.min(Number.MAX_SAFE_INTEGER, this.uiSalary)))) {
                 this.uiSalary = Math.max(1, this.previousUiSalary);
             }
             this.previousUiSalary = this.uiSalary;
@@ -179,13 +179,13 @@ let app = new Vue({
 
         calculateReliefTaxAmount: function() {
             const cpfTopUpMax = this.isPermanentResident ? 8000 : 0;
-            if(this.cpfTopUp !== Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp)) {
+            if (this.cpfTopUp !== Math.max(0, this.cpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.cpfTopUp)) {
                 this.cpfTopUp = Math.max(0, this.previousCpfTopUp > cpfTopUpMax ? cpfTopUpMax :this.previousCpfTopUp);
             }
             this.previousCpfTopUp = this.cpfTopUp;
 
             const srsTopUpMax = this.isPermanentResident ? 15300 : 35700;
-            if(this.srsTopUp !== Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp)) {
+            if (this.srsTopUp !== Math.max(0, this.srsTopUp > srsTopUpMax ? srsTopUpMax :  this.srsTopUp)) {
                 this.srsTopUp = Math.max(0, this.previousSrsTopUp > srsTopUpMax ? srsTopUpMax :this.previousSrsTopUp);
             }
             this.previousSrsTopUp = this.srsTopUp;


### PR DESCRIPTION
## Changes

- Disallow negative values.
- Keep salary in inclusive range 1 to `Number.MAX_SAFE_INTEGER` ($0 salary should not be encouraged).
- Revert to last known good value if field value evaluates to `NaN`.
- Fix non-residents erroneously getting SRS relief if it was enabled before switching to non-resident mode.